### PR TITLE
Fix invalid GBytes conversion on 32-bit system

### DIFF
--- a/glib/stream.go
+++ b/glib/stream.go
@@ -72,7 +72,7 @@ func (v *Bytes) Unref() {
 // BytesNew is a wrapper around g_bytes_new().
 func BytesNew(bytes []byte) (*Bytes, error) {
 	b := (C.gconstpointer)(unsafe.Pointer(&bytes[0]))
-	c := C.g_bytes_new(b, C.ulong(len(bytes)))
+	c := C.g_bytes_new(b, C.gsize(len(bytes)))
 	if c == nil {
 		return nil, errNilPtr
 	}


### PR DESCRIPTION
Attempt to compile GOTK3 on 32-bit system (x86 debian) causes an error:
```
glib/stream.go:75:28: cannot use _Ctype_long(len(bytes)) (type _Ctype_long) as type _Ctype_uint in assignment
```